### PR TITLE
Remove configuration from path to project .exe file for MSVC builds

### DIFF
--- a/cmake/copy_qt5_dlls_to_bin_dir.cmake
+++ b/cmake/copy_qt5_dlls_to_bin_dir.cmake
@@ -9,7 +9,7 @@ if (MSVC)
     add_custom_command(TARGET ${PROJECT_NAME}
         POST_BUILD
         COMMAND "${QT5_BIN_DIR}/qtenv2.bat"
-        COMMAND "${QT5_BIN_DIR}/windeployqt" --no-translations "${CMAKE_CURRENT_BINARY_DIR}/$<CONFIGURATION>/${PROJECT_NAME}.exe"
+        COMMAND "${QT5_BIN_DIR}/windeployqt" --no-translations "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}.exe"
         WORKING_DIRECTORY "${QT5_BIN_DIR}"
         COMMENT "Copy Qt5 dlls for ${PROJECT_NAME}"
     )


### PR DESCRIPTION
When building with both Visual Studio 2015 Community Edition and Visual Studio 2017 Community Edition, the directory containing the built .exe file is of the form:
   <user-path>\build-openhantek-Desktop_Qt_n_n_n_MSVC201[57]_64bit-Default\openhantek\
rather than
   <user-path>\build-openhantek-Desktop_Qt_n_n_n_MSVC201[57]_64bit-Default\openhantek\Debug\
or
   <user-path>\build-openhantek-Desktop_Qt_n_n_n_MSVC201[57]_64bit-Default\openhantek\Release\
The final step of the built process (running windeployqt) currently fails and my proposed change fixes this.
I have not been able to test the build process with MSVC compilers earlier than 2015.  Openhantek fails to compile on MSVC 2013 Update 3 and later due to the compiler not supporting list initialisation (https://msdn.microsoft.com/en-gb/library/Dn793970.aspx)